### PR TITLE
fix(cask): version interpolation, verified URL, symbol syntax

### DIFF
--- a/Casks/desktop.rb
+++ b/Casks/desktop.rb
@@ -2,12 +2,13 @@ cask "desktop" do
   version "0.0.41"
   sha256 "27df3e07c304b798f5f3b15fb672022a6231938f9fe398f565622e9b4c6a3a7e"
 
-  url "https://github.com/datum-cloud/app/releases/download/v0.0.41/Datum.dmg"
+  url "https://github.com/datum-cloud/app/releases/download/v#{version}/Datum.dmg",
+    verified: "github.com/datum-cloud/app/"
   name "Datum"
   desc "Quickly and safely expose local environments to the internet, for free."
   homepage "https://www.datum.net/"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
 
   app "Datum.app"
 end


### PR DESCRIPTION
## Summary

- Use `#{version}` interpolation in URL instead of hardcoded version string
- Add `verified:` domain to satisfy Homebrew URL audit
- Change `">= :big_sur"` string to `:big_sur` symbol (correct Homebrew idiom)